### PR TITLE
Probably config object is not finalized.

### DIFF
--- a/lib/vagrant-multi-putty/command.rb
+++ b/lib/vagrant-multi-putty/command.rb
@@ -39,6 +39,7 @@ module VagrantMultiPutty
     end
 
     def putty_connect(vm, args, plain_auth=False)
+      vm.config.putty.finalize!
       ssh_info = vm.ssh_info
       # If ssh_info is nil, the machine is not ready for ssh.
       raise Vagrant::Errors::SSHNotReady if ssh_info.nil?


### PR DESCRIPTION
error occured

C:\vagrant\test>vagrant putty

C:/Users/nazoking/.vagrant.d/gems/gems/vagrant-multi-putty-1.1.0/lib/vagrant-multi-putty/command.rb:67:in `spawn': can't convert Object into String (TypeError)
        from C:/Users/nazoking/.vagrant.d/gems/gems/vagrant-multi-putty-1.1.0/lib/vagrant-multi-putty/command.rb:67:in`putty_connect'

log is
  Putty cmd line options: ["127.0.0.1", "-l", #Object:0x2a0af50, "-P", "2222", "-i", "C:/vagrant/test/#Object:0x2a0af50"]

Probably config object is not finalized.
