### PR TITLE
Use no explicit key file when `private_key_path` is `:agent`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ There are currently a few additional configuration parameters available:
 *    `config.putty.username`: Overrides the username set with
     ` config.ssh.username`.
 *    `config.putty.private_key_path`: Used to explicity set the path to the
-     private key variable.
+     private key variable. When set to `:agent`, no private key file is supplied
+     and PuTTY will try private keys loaded by Pageant.
 *    `config.putty.modal`: change vagrant-multi-putty to use modal window mode.
      Execute putty and block the terminal until all putty processes have exited.
      Can be set on the command line with `-m` or `--modal`. This is false by default.

--- a/lib/vagrant-multi-putty/command.rb
+++ b/lib/vagrant-multi-putty/command.rb
@@ -89,7 +89,8 @@ module VagrantMultiPutty
       private_key = vm.config.putty.private_key_path ||
         ssh_info[:private_key_path][0] + ".ppk"
       @logger.debug("Putty Private Keys: #{private_key.to_s}")
-      ssh_options += ["-i", private_key] unless options[:plain_auth]
+      ssh_options += ["-i", private_key] unless
+        options[:plain_auth] || private_key == :agent
 
       # Add in additional args from the command line.
       ssh_options.concat(args) if !args.nil?


### PR DESCRIPTION
Basically, I wanted a Vagrantfile setting to instruct vagrant-multi-putty to use keys from Pageant. This is actually the same effect as `-p`, but in the Vagrantfile so you don't have to specify it all the time.

I considered using a separate setting or somehow turning `nil` into this, but a special symbol seemed like the best solution to me.
