### PR TITLE
Automatically convert keys to PuTTY's .ppk format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,32 +21,14 @@ Download the putty executable for your platform and add it's location to your
 PATH environment variable. Seek your operating system manual for instructions
 on how to modify your PATH variable.
 
-### SSH Private Key conversion using PuTTYgen
-Download: http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html
-
-Putty uses a custom format for SSH keys. It does not support openssl keys
-directly. Using PuTTYgen, you can convert the private key shipped with vagrant
-or convert a private key of your own.
-
-#### Steps for converting the shipped insecure private key
- 1. Open puttygen and click the Conversions -> Import Key menu option.
- 2. Select the insecure_private_key located at ~/.vagrant.d/insecure_private_key
- 3. Click the "Save private key" button and store the key right along side the
-    insecure key.
- 4. Answer yes when prompted to save without a password.
- 5. Save the key using the filename of "private_key.ppk".
-
-If you do not explicity set the `config.putty.private_key_path`
-variable, you need to convert the insecure_private_key and store it
-with a ".ppk" extension. The vagrant-multi-putty plugin appends this
-extension automatically.
+### SSH Private Key conversion
+SSH keys will be automatically converted to the ppk format used by putty.
 
 As of Vagrant 1.4.0, the `config.ssh.private_key_path` variable is converted into
 an array. This allows multiple SSH keys to be passed to ssh. PuTTY does not
 allow for a list of ssh keys via the command line. Therefore, if the
 `config.putty.private_key_path` variable is not set, we attempt to use the first
-key in the `config.ssh.private_key_path` list and append the '.ppk' extension
-to it.
+key in the `config.ssh.private_key_path` list.
 
 ## Configuration
 Most of the ssh configuration options used to control vagrant ssh also
@@ -55,7 +37,6 @@ vagrant-multi-putty:
 
 *    `config.ssh.max_tries`
 *    `config.ssh.timeout`
-*    `config.ssh.private_key_path`
 *    `config.ssh.shell`
 
 All other config.ssh options should work for vagrant-multi-putty just like they

--- a/vagrant-multi-putty.gemspec
+++ b/vagrant-multi-putty.gemspec
@@ -11,8 +11,11 @@ Gem::Specification.new do |s|
   s.summary     = "Vagrant plugin to allow VM ssh with PuTTY (multi-vm supported)"
   s.description = "Vagrant plugin to allow VM ssh with PuTTY (multi-vm supported)"
 
+  s.required_ruby_version = ">= 2.1.0"
   s.required_rubygems_version = ">= 1.4.0"
 
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
+  
+  s.add_runtime_dependency "putty-key", "~> 1.0"
 end


### PR DESCRIPTION
This is an alternative way to resolve #15 without requiring the PuTTY maintainers to start distributing a new command line tool (as is necessary for the approach taken with pull request #19).

I've created a library called [PuTTY::Key](https://github.com/philr/putty-key) that can handle the conversion of private keys to PuTTY's .ppk format. This requires only the Ruby OpenSSL standard library - it has no dependency on PuTTY or any of its related tools.

This pull request modifies vagrant-multi-putty to use PuTTY::Key to automatically convert the SSH key to a .ppk file when needed.

PuTTY::Key depends on Ruby 2.1 or later, so I've updated the `required_ruby_version` accordingly. This shouldn't cause a problem since Vagrant is currently using Ruby 2.2.