### PR TITLE
Support putty compatible ssh clients like kitty.

### DIFF
--- a/lib/vagrant-multi-putty/command.rb
+++ b/lib/vagrant-multi-putty/command.rb
@@ -9,14 +9,14 @@ using PuTTY::Key
 module VagrantMultiPutty
   class Command < Vagrant.plugin(2, :command)
     def execute
-      
+
       # config_global is deprecated from v1.5
       if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new('1.5')
         @config = @env.vagrantfile.config
       else
         @config = @env.config_global
       end
-      
+
       options = {:modal => @config.putty.modal,
                  :plain_auth => false }
       opts = OptionParser.new do |opts|
@@ -101,13 +101,13 @@ module VagrantMultiPutty
 
       # Spawn putty and detach it so we can move on.
       @logger.debug("Putty cmd line options: #{ssh_options.to_s}")
-      pid = spawn("putty", *ssh_options)
+      pid = spawn(@config.putty.ssh_client, *ssh_options)
       @logger.debug("Putty Child Pid: #{pid}")
       Process.detach(pid)
     end
-    
+
     private
-    
+
     def get_putty_key_file(ssh_key_path)
       "#{ssh_key_path}.ppk".tap do |ppk_path|
         if !File.exist?(ppk_path) || File.mtime(ssh_key_path) > File.mtime(ppk_path)

--- a/lib/vagrant-multi-putty/config.rb
+++ b/lib/vagrant-multi-putty/config.rb
@@ -5,6 +5,7 @@ module VagrantMultiPutty
 	attr_accessor :after_modal_hook
 	attr_accessor :modal
 	attr_accessor :session
+	attr_accessor :ssh_client
 
 	def after_modal &proc
 	  @after_modal_hook = proc
@@ -16,6 +17,7 @@ module VagrantMultiPutty
 	  @after_modal_hook = UNSET_VALUE
 	  @modal = UNSET_VALUE
 	  @session = UNSET_VALUE
+	  @ssh_client = UNSET_VALUE
 	end
 
 	def finalize!
@@ -24,6 +26,7 @@ module VagrantMultiPutty
 	  @after_modal_hook = Proc.new{  } if @after_modal_hook == UNSET_VALUE
 	  @modal = false if @modal == UNSET_VALUE
 	  @session = nil if @session == UNSET_VALUE
+	  @ssh_client = "putty" if @ssh_client == UNSET_VALUE
 	end
 
 	def validate(machine)

--- a/lib/vagrant-multi-putty/plugin.rb
+++ b/lib/vagrant-multi-putty/plugin.rb
@@ -5,7 +5,8 @@ module VagrantMultiPutty
     name "vagrant-multi-putty"
     description <<-DESC
       Vagrant-multi-putty allows you to ssh into your virtual machines using the putty
-      program. This plugin also supports opening putty sessions into multi-vm environments.
+      program (or other compatible ssh clients like kitty). This plugin also supports
+      opening putty sessions into multi-vm environments.
     DESC
 
     command "putty" do


### PR DESCRIPTION
By default, still uses putty to not break backwards compatability. Using

    config.putty.ssh_client = "kitty"

instead of putty, kitty is used (assuming on $PATH).

Resolves #22