### PR TITLE
Protocol ssh default and optional in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ There are currently a few additional configuration parameters available:
      once all child putty processes have exited and modal mode is enabled. The
      default block is empty.
 *    `config.putty.session`: Load settings from a saved putty session.
-*    `config.putty.ssh_client`: Allow end users to control the path to the putty or putty like (kitty for example) binary.
+*    `config.putty.ssh_client`: Allow end users to control the path to the putty
+     or putty like (kitty for example) binary.
+	 Use slashes (not backslashes) for full path under Windows, for example:
+	 config.putty.ssh_client = "C:/Program Files (x86)/PuTTY/putty.exe"
+*    `config.putty.ssh_options`: Allow end users define the Connection type or
+     any other arguments. Default is `-ssh`.
 
 #### Example usage of after_modal post hook
 This is an example which uses the the win32-activate gem written by nazoking. This

--- a/lib/vagrant-multi-putty/command.rb
+++ b/lib/vagrant-multi-putty/command.rb
@@ -96,6 +96,16 @@ module VagrantMultiPutty
       ssh_options += ["-i", private_key] unless
         options[:plain_auth] || private_key == :agent
 
+      # Set Connection type to -ssh, in cases other protocol
+      # stored in Default Settings of Putty.
+      if vm.config.putty.ssh_options
+        if vm.config.putty.ssh_options.class == Array
+          ssh_options += vm.config.putty.ssh_options
+        else
+          ssh_options += [vm.config.putty.ssh_options]
+        end
+      end
+
       # Add in additional args from the command line.
       ssh_options.concat(args) if !args.nil?
 

--- a/lib/vagrant-multi-putty/config.rb
+++ b/lib/vagrant-multi-putty/config.rb
@@ -6,6 +6,7 @@ module VagrantMultiPutty
 	attr_accessor :modal
 	attr_accessor :session
 	attr_accessor :ssh_client
+	attr_accessor :ssh_options
 
 	def after_modal &proc
 	  @after_modal_hook = proc
@@ -18,6 +19,7 @@ module VagrantMultiPutty
 	  @modal = UNSET_VALUE
 	  @session = UNSET_VALUE
 	  @ssh_client = UNSET_VALUE
+	  @ssh_options = UNSET_VALUE
 	end
 
 	def finalize!
@@ -27,6 +29,7 @@ module VagrantMultiPutty
 	  @modal = false if @modal == UNSET_VALUE
 	  @session = nil if @session == UNSET_VALUE
 	  @ssh_client = "putty" if @ssh_client == UNSET_VALUE
+	  @ssh_options = "-ssh" if @ssh_options == UNSET_VALUE
 	end
 
 	def validate(machine)


### PR DESCRIPTION
Set "-ssh" as default option for Putty, to fix Issure #28.
Like Pull Request #23, but the user can disable it by setting
`config.putty.ssh_options = ""`

In config you can put more as one option to your box, for example a tunnel to the webserver:
`config.putty.ssh_options = "-ssh", "-L", "8080:localhost:80"`

I feel, it would be nice, that `vagrant putty` works for mostly all (new) users.
Using `vagrant putty -- -ssh` is of curse an alternate without this patch. But a typically new user in vagrant (like me) needs first to find what is the problem here with Putty. An advanced user, who changed the ssh_client, can also change ssh_options (example kitty). So, the default `-ssh` should be not a problem.
