### PR TITLE
Preliminary support for launching WinSCP instead of putty (--scp option)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v1.6.1 (2017-10-05)
+-------------------
+
+FEATURES:
+ * Added the option to run WinSCP instead of putty.
+
 v1.6.0 (2016-11-03)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ There are currently a few additional configuration parameters available:
 *    `config.putty.session`: Load settings from a saved putty session.
 *    `config.putty.ssh_client`: Allow end users to control the path to the putty
      or putty like (kitty for example) binary.
+*    `config.putty.scp_client`: Allow end users to control the path to the WinSCP binary.
      Use slashes (not backslashes) for full path under Windows, for example:
-     `config.putty.ssh_client = "C:/Program Files (x86)/PuTTY/putty.exe"`
+     `config.putty.ssh_client = "C:/Program Files (x86)/PuTTY/putty.exe"` and 
+     `config.putty.scp_client = "C:/Program Files (x86)/WinSCP/WinSCP.exe"`
 *    `config.putty.ssh_options`: Allow end users define the Connection type or
      any other arguments. Multiple options separaed by comma. Default is `-ssh`.
 
@@ -115,4 +117,9 @@ vagrant putty <name of vm>
 Pass putty options directly to the putty binary:
 ```
 vagrant putty -- -l testuser -i <path to private key>
+```
+
+Run WinSCP instead of putty:
+```
+vagrant putty --scp
 ```

--- a/lib/vagrant-multi-putty/config.rb
+++ b/lib/vagrant-multi-putty/config.rb
@@ -7,6 +7,7 @@ module VagrantMultiPutty
 	attr_accessor :session
 	attr_accessor :ssh_client
 	attr_accessor :ssh_options
+	attr_accessor :scp_client
 
 	def after_modal &proc
 	  @after_modal_hook = proc
@@ -20,6 +21,7 @@ module VagrantMultiPutty
 	  @session = UNSET_VALUE
 	  @ssh_client = UNSET_VALUE
 	  @ssh_options = UNSET_VALUE
+	  @scp_client = UNSET_VALUE
 	end
 
 	def finalize!
@@ -30,6 +32,7 @@ module VagrantMultiPutty
 	  @session = nil if @session == UNSET_VALUE
 	  @ssh_client = "putty" if @ssh_client == UNSET_VALUE
 	  @ssh_options = "-ssh" if @ssh_options == UNSET_VALUE
+	  @scp_client = "winscp.exe" if @scp_client == UNSET_VALUE
 	end
 
 	def validate(machine)

--- a/lib/vagrant-multi-putty/version.rb
+++ b/lib/vagrant-multi-putty/version.rb
@@ -1,3 +1,3 @@
 module VagrantMultiPutty
-  VERSION = "1.6.0"
+  VERSION = "1.6.1"
 end


### PR DESCRIPTION
Preliminary support for running WinSCP binary instead of putty (using --scp option). Useful because WinSCP supports private key authorization.